### PR TITLE
Depend on psycopg2 >= 2.5 as README states

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     license="MIT",
     url='https://github.com/binarydud/redshift_sqlalchemy',
     packages=['redshift_sqlalchemy'],
-    install_requires=['psycopg2==2.5', 'SQLAlchemy>=0.8.0'],
+    install_requires=['psycopg2>=2.5', 'SQLAlchemy>=0.8.0'],
     include_package_data=True,
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
psycopg2 (2.5.2) has fixes some C code that caused SEGFAULTs, so I'd like to explicitly depend on 2.5.2 in my requirements, but the "==" forces a (very) specific version.
