### PR TITLE
fix create table -- `dialect_options` issue

### DIFF
--- a/redshift_sqlalchemy/dialect.py
+++ b/redshift_sqlalchemy/dialect.py
@@ -52,8 +52,7 @@ class RedShiftDDLCompiler(PGDDLCompiler):
 
     def post_create_table(self, table):
         text = ""
-        info = table.dialect_options['redshift']
-        diststyle = info.get('diststyle', None)
+        diststyle = table.kwargs.get('redshift_diststyle', None)
         if diststyle:
             diststyle = diststyle.upper()
             if diststyle not in ('EVEN', 'KEY', 'ALL'):
@@ -61,11 +60,11 @@ class RedShiftDDLCompiler(PGDDLCompiler):
                                u"diststyle {0} is invalid".format(diststyle))
             text += " DISTSTYLE " + diststyle
 
-        distkey = info.get('distkey', None)
+        distkey = table.kwargs.get('redshift_distkey', None)
         if distkey:
             text += " DISTKEY ({0})".format(distkey)
 
-        sortkey = info.get('sortkey', None)
+        sortkey = table.kwargs.get('redshift_sortkey', None)
         if sortkey:
             if isinstance(sortkey, str):
                 keys = (sortkey,)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ class PyTest(TestCommand):
 
 setup(
     name='redshift-sqlalchemy',
-    version='0.5.0a',
+    version='0.4.1-run2',
     description='Amazon Redshift Dialect for sqlalchemy',
     long_description=open("README.rst").read(),
     author='Matt George',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ class PyTest(TestCommand):
 
 setup(
     name='redshift-sqlalchemy',
-    version='0.4.1-run2',
+    version='0.5.0a',
     description='Amazon Redshift Dialect for sqlalchemy',
     long_description=open("README.rst").read(),
     author='Matt George',


### PR DESCRIPTION
If I was doing something wrong and this change doesn't make sense, please let me know, but I was having the following issue trying to create a table with alembic. There doesn't appear to be a `dialect_options` on `Table`. In another dialect (MySQL), I saw that they use `table.kwargs` instead (I'm looking at SQLAlchemy 0.8.7). This PR uses that strategy.

```
(aud)vagrant@vagrant-ubuntu-trusty-64:/vagrant/run_audience/analytics$ alembic -c alembic-dev.ini revision --autogenerate -m 'init'
INFO  [alembic.migration] Context impl RedshiftImpl.
INFO  [alembic.migration] Will assume transactional DDL.
Traceback (most recent call last):
  File "/home/vagrant/aud/bin/alembic", line 9, in <module>
    load_entry_point('alembic==0.7.0', 'console_scripts', 'alembic')()
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/alembic/config.py", line 399, in main
    CommandLine(prog=prog).main(argv=argv)
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/alembic/config.py", line 393, in main
    self.run_cmd(cfg, options)
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/alembic/config.py", line 376, in run_cmd
    **dict((k, getattr(options, k)) for k in kwarg)
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/alembic/command.py", line 113, in revision
    script.run_env()
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/alembic/script.py", line 382, in run_env
    util.load_python_file(self.dir, 'env.py')
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/alembic/util.py", line 241, in load_python_file
    module = load_module_py(module_id, path)
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/alembic/compat.py", line 79, in load_module_py
    mod = imp.load_source(module_id, path, fp)
  File "alembic-redshift/env.py", line 78, in <module>
    run_migrations_online()
  File "alembic-redshift/env.py", line 71, in run_migrations_online
    context.run_migrations()
  File "<string>", line 7, in run_migrations
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/alembic/environment.py", line 737, in run_migrations
    self.get_context().run_migrations(**kw)
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/alembic/migration.py", line 292, in run_migrations
    self._ensure_version_table()
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/alembic/migration.py", line 245, in _ensure_version_table
    self._version.create(self.connection, checkfirst=True)
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/sqlalchemy/schema.py", line 616, in create
    checkfirst=checkfirst)
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1122, in _run_visitor
    **kwargs).traverse_single(element)
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/sqlalchemy/sql/visitors.py", line 122, in traverse_single
    return meth(obj, **kw)
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/sqlalchemy/engine/ddl.py", line 89, in visit_table
    self.connection.execute(schema.CreateTable(table))
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 662, in execute
    params)
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 714, in _execute_ddl
    compiled = ddl.compile(dialect=dialect)
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/sqlalchemy/sql/expression.py", line 2431, in compile
    return self._compiler(dialect, bind=bind, **kw)
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/sqlalchemy/schema.py", line 2958, in _compiler
    return dialect.ddl_compiler(dialect, self, **kw)
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/sqlalchemy/engine/interfaces.py", line 804, in __init__
    self.string = self.process(self.statement, **compile_kwargs)
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/sqlalchemy/engine/interfaces.py", line 823, in process
    return obj._compiler_dispatch(self, **kwargs)
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/sqlalchemy/sql/visitors.py", line 80, in _compiler_dispatch
    return meth(self, **kw)
  File "/home/vagrant/aud/local/lib/python2.7/site-packages/sqlalchemy/sql/compiler.py", line 1986, in visit_create_table
    text += "\n)%s\n\n" % self.post_create_table(table)
  File "/home/vagrant/aud/src/redshift-sqlalchemy/redshift_sqlalchemy/dialect.py", line 55, in post_create_table
    info = table.dialect_options['redshift']
AttributeError: 'Table' object has no attribute 'dialect_options'
```

Note: to reproduce this through alembic, you would need to [follow Michael Bayer's instructions](https://groups.google.com/forum/#!msg/sqlalchemy-alembic/9mnBXhtVTJA/teif-V97x9EJ) to get over the first hurdle of not having an Impl.
