### PR TITLE
redshift does not support sequences

### DIFF
--- a/redshift_sqlalchemy/dialect.py
+++ b/redshift_sqlalchemy/dialect.py
@@ -114,6 +114,8 @@ class RedShiftDDLCompiler(PGDDLCompiler):
 
 class RedshiftDialect(PGDialect_psycopg2):
     name = 'redshift'
+    supports_sequences = False
+    preexecute_autoincrement_sequences = False
     ddl_compiler = RedShiftDDLCompiler
 
     construct_arguments = [


### PR DESCRIPTION
I hit this problem while trying to insert data in table with an identity column.  The postgresql equivalent would be to user a sequence, but those are not supported in redshift, so I get an error along the lines that it cannot find the sequence for the identity column.  I believe this is the problem seen in https://github.com/binarydud/redshift_sqlalchemy/issues/24