### PR TITLE
redshift does not support sequences

### DIFF
--- a/redshift_sqlalchemy/dialect.py
+++ b/redshift_sqlalchemy/dialect.py
@@ -114,6 +114,8 @@ class RedShiftDDLCompiler(PGDDLCompiler):
 
 class RedshiftDialect(PGDialect_psycopg2):
     name = 'redshift'
+    supports_sequences = False
+    preexecute_autoincrement_sequences = False
     ddl_compiler = RedShiftDDLCompiler
 
     construct_arguments = [


### PR DESCRIPTION
Reopening this as it was incorrectly closed earlier.  The problem is not fixed for inserting into an existing table, only for creating a new table.